### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v1.3.17
+- Bug fix for showing "No errors logged" when smartctl returned "Error Counter logging not supported" due to missing `-d sat` or `-d sas`. Issue #30
+
 v1.3.16
 - Added TB/GB/MB for NVMe data_units_read and data_units_written.
 

--- a/syno_smart_info.sh
+++ b/syno_smart_info.sh
@@ -22,7 +22,7 @@
 # https://www.disktuna.com/seagate-raw-smart-attributes-to-error-convertertest/#102465319
 #------------------------------------------------------------------------------
 
-scriptver="v1.3.16"
+scriptver="v1.3.17"
 script=Synology_SMART_info
 repo="007revad/Synology_SMART_info"
 
@@ -544,7 +544,7 @@ show_health(){
     #"$smartctl" -l error /dev/"$drive" | grep -iE 'error.*logg'
 
     # Retrieve Error Log and show error count
-    errlog="$("$smartctl" -l error /dev/"$drive" | grep -iE 'error.*logg')"
+    errlog="$("$smartctl" -l error -d $drive_type /dev/"$drive" | grep -iE 'error.*logg')"
     errcount="$(echo "$errlog" | awk '{print $3}')"
     #echo "$errlog"
     if [[ $errcount -gt "0" ]]; then


### PR DESCRIPTION
v1.3.17
- Bug fix for showing "No errors logged" when smartctl returned "Error Counter logging not supported" due to missing `-d sat` or `-d sas`. Issue #30